### PR TITLE
Collision

### DIFF
--- a/Collider.cpp
+++ b/Collider.cpp
@@ -2,7 +2,8 @@
 #include "Collider.h"
 #include "Object.h"
 #include "Transform.h"
-#include "Player.h"
+#include "Human.h"
+#include "Tomato.h"
 
 Collider::Collider()
 	: flag(false)
@@ -43,7 +44,7 @@ void Collider::CollisionCheck()
 		{
 			distance = distance * -1.0f;
 		}
-		// 範囲に入っているトマトの壁からトマトを回収
+
 		if (distance < 10.0f)
 		{
 			flag = true;
@@ -52,6 +53,13 @@ void Collider::CollisionCheck()
 		}
 		flag = false;
 	}
+}
+
+void Collider::Shot(VECTOR& position, VECTOR& dir)
+{
+	Object* obj = new Object;
+	obj->AddComponent<Tomato>()->Init(position, dir);
+	copyObjectList->push_back(obj);
 }
 
 double Collider::GetDistance(VECTOR& pos1, VECTOR& pos2)

--- a/Collider.cpp
+++ b/Collider.cpp
@@ -4,6 +4,7 @@
 #include "Transform.h"
 #include "Human.h"
 #include "Tomato.h"
+#include "Score.h"
 
 Collider::Collider()
 	: flag(false)
@@ -59,6 +60,9 @@ void Collider::CollisionCheck()
 					continue;
 				}
 				// ここにカプセル化したスコア管理クラスを呼べばいいと思う
+				if (tag == ObjectTag::Player1) { Score::AddTeam1Score(); }
+				if (tag == ObjectTag::Player2) { Score::AddTeam2Score(); }
+				if (tag == ObjectTag::Enemy) { Score::AddTeam3Score(); }
 			}
 			flag = true;
 			break;

--- a/Collider.cpp
+++ b/Collider.cpp
@@ -30,12 +30,15 @@ void Collider::CollisionCheck()
 {
 	auto self = m_pParent;
 	auto selfPosition = self->GetComponent<Transform>()->position;
+	auto selfTag = self->GetComponent<Tag>();
 	for (auto obj : *copyObjectList)
 	{
 		if (self == obj) { continue; }	// 自分以外のオブジェクトと判定するため
 		Transform* trans = nullptr;
 		trans = obj->GetComponent<Transform>();
 		if (trans == nullptr) { continue; }	// Transformをコンポーネントしていないものと判定はしない
+		auto L_tag = obj->GetComponent<Tag>();
+		if (L_tag == nullptr) { continue; } // Tagをコンポーネントしていないものと判定しない
 		float distance = 0.0f;
 		distance = GetDistance(selfPosition, trans->position);
 
@@ -45,21 +48,33 @@ void Collider::CollisionCheck()
 			distance = distance * -1.0f;
 		}
 
-		if (distance < 10.0f)
+		if (distance < width)
 		{
+			if (L_tag->tag == ObjectTag::tomato)	// 当たったのはトマトだった
+			{
+				auto tomato = obj->GetComponent<Tomato>();
+				tag = tomato->m_tag->tag;	// だれが投げたトマト？（当たった人のタグはいらないと思う。当たる人だけコライダーをコンポーネントさせる）
+				if (selfTag->tag == tag)	// 自分が投げたトマトだったので無視
+				{
+					continue;
+				}
+				// ここにカプセル化したスコア管理クラスを呼べばいいと思う
+			}
 			flag = true;
-			tag = obj->GetComponent<Tag>()->tag;
 			break;
 		}
 		flag = false;
 	}
 }
 
-void Collider::Shot(VECTOR& position, VECTOR& dir)
+void Collider::Shot(VECTOR position, VECTOR dir, Tag* tag)
 {
 	Object* obj = new Object;
-	obj->AddComponent<Tomato>()->Init(position, dir);
-	copyObjectList->push_back(obj);
+	obj->AddComponent<Transform>();
+	auto L_tag = obj->AddComponent<Tag>();
+	L_tag->tag = ObjectTag::tomato;
+	obj->AddComponent<Tomato>()->Init(position, dir, tag);
+	copyObjectList->push_front(obj);
 }
 
 double Collider::GetDistance(VECTOR& pos1, VECTOR& pos2)

--- a/Collider.h
+++ b/Collider.h
@@ -12,6 +12,7 @@ public:
 	void Init(std::list<Object*>* objectLists);		// シーンのオブジェクトリストを参照渡しでみる
 	void Update();
 	void CollisionCheck();
+	void Shot(VECTOR& position, VECTOR& dir);
 	double GetDistance(VECTOR& pos1, VECTOR& pos2);
 	const bool& Getflag() const { return flag; }
 	const ObjectTag& GetTag()const { return tag; }

--- a/Collider.h
+++ b/Collider.h
@@ -12,7 +12,7 @@ public:
 	void Init(std::list<Object*>* objectLists);		// シーンのオブジェクトリストを参照渡しでみる
 	void Update();
 	void CollisionCheck();
-	void Shot(VECTOR& position, VECTOR& dir);
+	void Shot(VECTOR position, VECTOR dir, Tag* tag);
 	double GetDistance(VECTOR& pos1, VECTOR& pos2);
 	const bool& Getflag() const { return flag; }
 	const ObjectTag& GetTag()const { return tag; }

--- a/ColliderManager.h
+++ b/ColliderManager.h
@@ -1,6 +1,0 @@
-#pragma once
-
-class ColliderManager
-{
-
-};

--- a/Enemy.cpp
+++ b/Enemy.cpp
@@ -41,15 +41,20 @@ Enemy::~Enemy()
 {
 	MV1DeleteModel(m_modelHandle);
 
-	for (int i = 0; i < m_tomatos.size(); i++)
-	{
-		if (!m_tomatos[i])
-		{
-			delete(m_tomatos[i]);
-		}
-		m_tomatos.erase(std::cbegin(m_tomatos) + i);
-		m_tomatos.shrink_to_fit();
-	}
+	//for (int i = 0; i < m_tomatos.size(); i++)
+	//{
+	//	if (!m_tomatos[i])
+	//	{
+	//		delete(m_tomatos[i]);
+	//	}
+	//	m_tomatos.erase(std::cbegin(m_tomatos) + i);
+	//	m_tomatos.shrink_to_fit();
+	//}
+}
+
+void Enemy::Start()
+{
+	m_position = m_pParent->GetComponent<Transform>()->position;
 }
 
 void Enemy::Update()
@@ -72,6 +77,8 @@ void Enemy::Update()
 	MV1SetRotationXYZ(m_modelHandle, m_dir);
 
 	// 3Dモデルのポジション設定
+	auto pos = m_pParent->GetComponent<Transform>();
+	pos->position = m_position;
 	MV1SetPosition(m_modelHandle, m_position);
 }
 
@@ -81,11 +88,11 @@ void Enemy::Draw()
 	// 3Dモデルの描画
 	MV1DrawModel(m_modelHandle);
 
-	// トマト描画
-	for (int i = 0; i < m_tomatos.size(); i++)
-	{
-		m_tomatos[i]->Draw();
-	}
+	//// トマト描画
+	//for (int i = 0; i < m_tomatos.size(); i++)
+	//{
+	//	m_tomatos[i]->Draw();
+	//}
 	SetUseLighting(true);
 
 	DrawFormatString(500, 0, GetColor(255, 255, 255), "EnemyBulletNum:%d", m_bulletNum);
@@ -109,26 +116,26 @@ void Enemy::ProcessTomato()
 	if (m_shotTime > 100.0f && m_moveType == Type::AimTarget && m_bulletNum > 0)
 	{
 		//m_tomatos.push_back(new Tomato(m_position, m_tomatoDir));
-		m_pParent->GetComponent<Collider>()->Shot(m_position, m_tomatoDir);
+		m_pParent->GetComponent<Collider>()->Shot(m_position, m_tomatoDir, m_pParent->GetComponent<Tag>());
 		m_bulletNum--;
 		m_shotTime = 0.0f;
 	}
 
 	// トマト処理
-	for (int i = 0; i < m_tomatos.size(); i++)
-	{
-		m_tomatos[i]->Update();
-	}
-	for (int i = 0; i < m_tomatos.size(); i++)
-	{
-		// トマトの生存時間が5.0fを超えると削除
-		if (m_tomatos[i]->GetTime() > 1.0f)
-		{
-			delete(m_tomatos[i]);
-			m_tomatos.erase(std::cbegin(m_tomatos) + i);
-			m_tomatos.shrink_to_fit();
-		}
-	}
+	//for (int i = 0; i < m_tomatos.size(); i++)
+	//{
+	//	m_tomatos[i]->Update();
+	//}
+	//for (int i = 0; i < m_tomatos.size(); i++)
+	//{
+	//	// トマトの生存時間が5.0fを超えると削除
+	//	if (m_tomatos[i]->GetTime() > 1.0f)
+	//	{
+	//		delete(m_tomatos[i]);
+	//		m_tomatos.erase(std::cbegin(m_tomatos) + i);
+	//		m_tomatos.shrink_to_fit();
+	//	}
+	//}
 }
 
 // @detail 標的がいる方向に正面を向ける

--- a/Enemy.cpp
+++ b/Enemy.cpp
@@ -5,6 +5,7 @@
 #include "ModelManager.h"
 #include "Object.h"
 #include "Transform.h"
+#include "Collider.h"
 
 Enemy::Enemy()
 	: m_movePhaseTime(50)
@@ -107,7 +108,8 @@ void Enemy::ProcessTomato()
 	m_shotTime++;
 	if (m_shotTime > 100.0f && m_moveType == Type::AimTarget && m_bulletNum > 0)
 	{
-		m_tomatos.push_back(new Tomato(m_position, m_tomatoDir));
+		//m_tomatos.push_back(new Tomato(m_position, m_tomatoDir));
+		m_pParent->GetComponent<Collider>()->Shot(m_position, m_tomatoDir);
 		m_bulletNum--;
 		m_shotTime = 0.0f;
 	}

--- a/Enemy.h
+++ b/Enemy.h
@@ -11,6 +11,7 @@ public:
 	Enemy();				// コンストラクタ
 	~Enemy();				// デストラクタ
 
+	void Start()override;	// コンポーネント初期化処理.
 	void Update()override;	// 更新処理.
 	void Draw()override;	// 描画処理.
 

--- a/Human.cpp
+++ b/Human.cpp
@@ -14,14 +14,14 @@ Human::Human()
 	m_pTransform = nullptr;
 	m_pTag = nullptr;
 
-	m_modelHandle = MV1LoadModel("data/character/man1.mv1");
+	//m_modelHandle = MV1LoadModel("data/character/man1.mv1");
 	m_velocity = VGet(0.0f, 0.0f, 0.0f);
 
 	// 3Dモデルの読み込み
-	//ModelManager* model = new ModelManager();
-	//srand(rand() % 100);
-	//int modelNum = rand() % MODEL_NUM;
-	//m_modelHandle = model->GetModelData(modelNum);
+	ModelManager* model = new ModelManager();
+	srand(rand() % 100);
+	int modelNum = rand() % MODEL_NUM;
+	m_modelHandle = model->GetModelData(modelNum);
 	MV1SetScale(m_modelHandle, VGet(0.1f, 0.1f, 0.1f));
 
 	m_dir = VGet(0.0f, 0.0f, 1.0f);
@@ -106,13 +106,7 @@ void Human::Draw()
 	// 3Dモデルの描画
 	SetUseLighting(false);
 	MV1DrawModel(m_modelHandle);
-	// トマト描画
-	//for (int i = 0; i < m_tomatos.size(); i++)
-	//{
-	//	m_tomatos[i]->Draw();
-	//}
 	SetUseLighting(true);
-	auto pos = m_pTransform->position;
 	int t = 0;
 	auto collider = m_pParent->GetComponent<Collider>();
 	if (collider->Getflag()) 
@@ -121,7 +115,6 @@ void Human::Draw()
 		if (collider->tag == ObjectTag::tomato) { t = 2; }
 		if (collider->tag == ObjectTag::Player2) { t = 3; }
 	}
-	printfDx("x:%f y:%f z:%f flag:%d\n", pos.x, pos.y, pos.z, t);
 }
 
 void Human::Input()

--- a/Human.cpp
+++ b/Human.cpp
@@ -89,11 +89,6 @@ void Human::Update()
 	}
 	MV1SetAttachAnimTime(m_modelHandle, m_animIndex, m_animTime);
 
-	// トマト処理
-	for (int i = 0; i < m_tomatos.size(); i++)
-	{
-		m_tomatos[i]->Update();
-	}
 	for (int i = 0; i < m_tomatos.size(); i++)
 	{
 		// トマトの生存時間が5.0fを超えると削除
@@ -120,7 +115,12 @@ void Human::Draw()
 	auto pos = m_pTransform->position;
 	int t = 0;
 	auto collider = m_pParent->GetComponent<Collider>();
-	if (collider->Getflag()) { t = 1; }
+	if (collider->Getflag()) 
+	{ 
+		if (collider->tag == ObjectTag::Enemy) { t = 1; }
+		if (collider->tag == ObjectTag::tomato) { t = 2; }
+		if (collider->tag == ObjectTag::Player2) { t = 3; }
+	}
 	printfDx("x:%f y:%f z:%f flag:%d\n", pos.x, pos.y, pos.z, t);
 }
 
@@ -142,7 +142,7 @@ void Human::Input()
 	m_moveFlag = false;
 
 	// 1Pの操作
-	if (m_pTag->tag == ObjectTag::Player2)
+	if (m_pTag->tag == ObjectTag::Player1)
 	{
 		// 入力状態を取得
 		GetJoypadXInputState(DX_INPUT_PAD2, &inputState);
@@ -191,10 +191,19 @@ void Human::Input()
 			inputVec = VAdd(left, inputVec);
 			input = true;
 		}
+
+		// トマト生成(Playerの回転処理が終わった後生成(上だとプレイヤーの向きにならず少しずれる))
+		if (Input::IsDown2P(BUTTON_ID_R)/* && m_bulletNum > 0*/)
+		{
+			//m_bulletNum--;
+			auto pos = m_pParent->GetComponent<Transform>()->position;
+			m_pParent->GetComponent<Collider>()->Shot(pos, m_dir, m_pParent->GetComponent<Tag>());
+			//m_effect->PlayEffect(m_position);
+		}
 	}
 
 	// 2Pの操作
-	if (m_pTag->tag == ObjectTag::Player1)
+	if (m_pTag->tag == ObjectTag::Player2)
 	{
 		// 入力状態を取得
 		GetJoypadXInputState(DX_INPUT_PAD1, &inputState);
@@ -243,6 +252,15 @@ void Human::Input()
 			inputVec = VAdd(left, inputVec);
 			input = true;
 		}
+
+		// トマト生成(Playerの回転処理が終わった後生成(上だとプレイヤーの向きにならず少しずれる))
+		if (Input::IsDown1P(BUTTON_ID_R)/* && m_bulletNum > 0*/)
+		{
+			//m_bulletNum--;
+			auto pos = m_pParent->GetComponent<Transform>()->position;
+			m_pParent->GetComponent<Collider>()->Shot(pos, m_dir, m_pParent->GetComponent<Tag>());
+			//m_effect->PlayEffect(m_position);
+		}
 	}
 
 	// 入力有（加速）・入力無（減速）
@@ -279,16 +297,8 @@ void Human::Input()
 
 	if (m_pParent->GetComponent<Collider>()->flag)
 	{
-		m_pTransform->position = VSub(m_pTransform->position, VScale(inputVec, 1.5f));
+		m_pTransform->position = VSub(m_pTransform->position, VScale(inputVec, 2.5f));
 		m_velocity = VGet(0.0f, 0.0f, 0.0f);
-	}
-	// トマト生成(Playerの回転処理が終わった後生成(上だとプレイヤーの向きにならず少しずれる))
-	if (Input::IsDown1P(BUTTON_ID_R)/* && m_bulletNum > 0*/)
-	{
-		//m_bulletNum--;
-		auto pos = m_pParent->GetComponent<Transform>()->position;
-		m_pParent->GetComponent<Collider>()->Shot(pos, m_dir);
-		//m_effect->PlayEffect(m_position);
 	}
 }
 

--- a/Human.cpp
+++ b/Human.cpp
@@ -112,10 +112,10 @@ void Human::Draw()
 	SetUseLighting(false);
 	MV1DrawModel(m_modelHandle);
 	// トマト描画
-	for (int i = 0; i < m_tomatos.size(); i++)
-	{
-		m_tomatos[i]->Draw();
-	}
+	//for (int i = 0; i < m_tomatos.size(); i++)
+	//{
+	//	m_tomatos[i]->Draw();
+	//}
 	SetUseLighting(true);
 	auto pos = m_pTransform->position;
 	int t = 0;
@@ -279,7 +279,7 @@ void Human::Input()
 
 	if (m_pParent->GetComponent<Collider>()->flag)
 	{
-		m_pTransform->position = VSub(m_pTransform->position, inputVec);
+		m_pTransform->position = VSub(m_pTransform->position, VScale(inputVec, 1.5f));
 		m_velocity = VGet(0.0f, 0.0f, 0.0f);
 	}
 	// トマト生成(Playerの回転処理が終わった後生成(上だとプレイヤーの向きにならず少しずれる))
@@ -287,8 +287,7 @@ void Human::Input()
 	{
 		//m_bulletNum--;
 		auto pos = m_pParent->GetComponent<Transform>()->position;
-		m_tomatos.push_back(new Tomato(pos, m_dir));
-
+		m_pParent->GetComponent<Collider>()->Shot(pos, m_dir);
 		//m_effect->PlayEffect(m_position);
 	}
 }

--- a/Human.h
+++ b/Human.h
@@ -36,6 +36,8 @@ private:
 
 	bool m_rotateNow;		// ‰ñ“]’†‚©”»’è—p
 
+
+
 	enum Anim
 	{
 		Idle,

--- a/Object.h
+++ b/Object.h
@@ -57,3 +57,5 @@ public:
 		return buff;
 	}
 };
+
+static std::list<Object*>m_pObjectLists;

--- a/ObjectTag.h
+++ b/ObjectTag.h
@@ -13,6 +13,7 @@ enum class ObjectTag : unsigned char
 	Player2Bullet,
 	Enemy,
 	EnemyBullet,
+	tomato,
 	TomatoWall,
 	Ground,
 	Camera1,

--- a/PlayScene.cpp
+++ b/PlayScene.cpp
@@ -13,6 +13,7 @@
 #include "TimeCount.h"
 #include "Image.h"
 #include "TimeUIController.h"
+#include "Score.h"
 
 
 // いたっんおいてる定数.いつの日かまとめる
@@ -83,6 +84,10 @@ PlayScene::PlayScene(const MODE& mode)
 	}
 
 	// iguchi
+	
+	// scoreクラスを初期化
+	Score::GetInstance();
+	
 	// playerを2つ生成
 	{
 		{
@@ -110,28 +115,28 @@ PlayScene::PlayScene(const MODE& mode)
 	}
 	// enemyを生成
 	{
-		//for (int i = 0; i < 2; i++)
-		//{
-		//	int num = 0;
-		//	Object* obj = new Object;
-		//	auto collider = obj->AddComponent<Collider>();
-		//	collider->Init(&m_pObjectLists); collider->width = 10.0f;
-		//	auto pos = obj->AddComponent<Transform>();
-		//	pos->position.x = 100 * i; pos->position.z = 100 * i;
-		//	obj->AddComponent<Tag>()->tag = ObjectTag::Enemy;
-		//	auto enemy = obj->AddComponent<Enemy>();
-		//	for (auto ob : m_pObjectLists)
-		//	{
-		//		enemy->SetPlayerPtr(ob);
-		//		num++;
-		//		if (num > 1) { break; }
-		//	}
-		//	for (int i = 0; i < m_tomatoWallNum; i++)
-		//	{
-		//		enemy->SetTomatoWallPtr(m_pTomatoWall[i]);
-		//	}
-		//	m_pObjectLists.push_back(obj);
-		//}
+		for (int i = 0; i < 2; i++)
+		{
+			int num = 0;
+			Object* obj = new Object;
+			auto collider = obj->AddComponent<Collider>();
+			collider->Init(&m_pObjectLists); collider->width = 10.0f;
+			auto pos = obj->AddComponent<Transform>();
+			pos->position.x = 100 * i; pos->position.z = 100 * i;
+			obj->AddComponent<Tag>()->tag = ObjectTag::Enemy;
+			auto enemy = obj->AddComponent<Enemy>();
+			for (auto ob : m_pObjectLists)
+			{
+				enemy->SetPlayerPtr(ob);
+				num++;
+				if (num > 1) { break; }
+			}
+			for (int i = 0; i < m_tomatoWallNum; i++)
+			{
+				enemy->SetTomatoWallPtr(m_pTomatoWall[i]);
+			}
+			m_pObjectLists.push_back(obj);
+		}
 	}
 	//	cameraを2つ生成
 	{
@@ -219,6 +224,7 @@ PlayScene::~PlayScene()
 	}
 	m_pObjectLists.clear();
 	m_pGameObjects.clear();
+	Score::Terminate();
 }
 
 TAG_SCENE PlayScene::Update()
@@ -247,6 +253,7 @@ void PlayScene::Draw()
 {
 #ifdef _DEBUG
 	printfDx("PlayScene\n");
+	printfDx("T1:%d T2:%d T3:%d\n", Score::GetTeam1Score(), Score::GetTeam2Score(), Score::GetTeam3Score());
 #endif // _DEBUG
 
 	switch (m_transition)

--- a/PlayScene.cpp
+++ b/PlayScene.cpp
@@ -84,7 +84,6 @@ PlayScene::PlayScene(const MODE& mode)
 
 
 	// iguchi
-	Collider* coll1,* coll2;
 	// playerを2つ生成
 	{
 		{
@@ -115,6 +114,9 @@ PlayScene::PlayScene(const MODE& mode)
 			int num = 0;
 			Object* obj = new Object;
 			auto enemy = obj->AddComponent<Enemy>();
+			obj->AddComponent<Collider>()->Init(&m_pObjectLists);
+			obj->AddComponent<Transform>();
+			obj->AddComponent<Tag>()->tag = ObjectTag::Enemy;
 			for (auto ob : m_pObjectLists)
 			{
 				enemy->SetPlayerPtr(ob);

--- a/PlayScene.cpp
+++ b/PlayScene.cpp
@@ -82,7 +82,6 @@ PlayScene::PlayScene(const MODE& mode)
 	//m_pGameObjects.push_back(m_pCamera2P);
 	}
 
-
 	// iguchi
 	// playerを2つ生成
 	{
@@ -92,43 +91,47 @@ PlayScene::PlayScene(const MODE& mode)
 			trs->position = VGet(0.0f, 0.0f, 0.0f);
 			auto tag = obj->AddComponent<Tag>();
 			tag->tag = ObjectTag::Player1;
-			obj->AddComponent<Collider>()->Init(&m_pObjectLists);
+			auto collider = obj->AddComponent<Collider>();
+			collider->Init(&m_pObjectLists); collider->width = 10.0f;
 			auto p1 = obj->AddComponent<Human>();
 			m_pObjectLists.push_back(obj);
 		}
 		{
 			Object* obj = new Object;
 			auto trs = obj->AddComponent<Transform>();
-			trs->position = VGet(20.0f, 0.0f, 20.0f);
+			trs->position = VGet(50.0f, 0.0f, 50.0f);
 			auto tag = obj->AddComponent<Tag>();
 			tag->tag = ObjectTag::Player2;
-			obj->AddComponent<Collider>()->Init(&m_pObjectLists);
+			auto collider = obj->AddComponent<Collider>();
+			collider->Init(&m_pObjectLists); collider->width = 10.0f;
 			auto p1 = obj->AddComponent<Human>();
 			m_pObjectLists.push_back(obj);
 		}
 	}
 	// enemyを生成
 	{
-		for (int i = 0; i < 2; i++)
-		{
-			int num = 0;
-			Object* obj = new Object;
-			auto enemy = obj->AddComponent<Enemy>();
-			obj->AddComponent<Collider>()->Init(&m_pObjectLists);
-			obj->AddComponent<Transform>();
-			obj->AddComponent<Tag>()->tag = ObjectTag::Enemy;
-			for (auto ob : m_pObjectLists)
-			{
-				enemy->SetPlayerPtr(ob);
-				num++;
-				if (num > 1) { break; }
-			}
-			for (int i = 0; i < m_tomatoWallNum; i++)
-			{
-				enemy->SetTomatoWallPtr(m_pTomatoWall[i]);
-			}
-			m_pObjectLists.push_back(obj);
-		}
+		//for (int i = 0; i < 2; i++)
+		//{
+		//	int num = 0;
+		//	Object* obj = new Object;
+		//	auto collider = obj->AddComponent<Collider>();
+		//	collider->Init(&m_pObjectLists); collider->width = 10.0f;
+		//	auto pos = obj->AddComponent<Transform>();
+		//	pos->position.x = 100 * i; pos->position.z = 100 * i;
+		//	obj->AddComponent<Tag>()->tag = ObjectTag::Enemy;
+		//	auto enemy = obj->AddComponent<Enemy>();
+		//	for (auto ob : m_pObjectLists)
+		//	{
+		//		enemy->SetPlayerPtr(ob);
+		//		num++;
+		//		if (num > 1) { break; }
+		//	}
+		//	for (int i = 0; i < m_tomatoWallNum; i++)
+		//	{
+		//		enemy->SetTomatoWallPtr(m_pTomatoWall[i]);
+		//	}
+		//	m_pObjectLists.push_back(obj);
+		//}
 	}
 	//	cameraを2つ生成
 	{

--- a/PlayScene.h
+++ b/PlayScene.h
@@ -49,7 +49,7 @@ private:
 	class Map* m_map;  // Map
   
 	std::vector<GameObject*>m_pGameObjects;
-	std::list<class Object*>m_pObjectLists;
+	//std::list<class Object*>m_pObjectLists;
 
 	const int m_tomatoWallNum = 2;
 

--- a/Player.cpp
+++ b/Player.cpp
@@ -270,9 +270,10 @@ void Player::Input()
 	if (Input::IsDown1P(BUTTON_ID_R) && m_bulletNum > 0)
 	{
 		m_bulletNum--;
-		m_tomatos.push_back(new Tomato(m_position, m_dir));
+		//m_tomatos.push_back(new Tomato(m_position, m_dir));
+		
     
-    m_effect->PlayEffect(m_position);
+		m_effect->PlayEffect(m_position);
 	}
 
 	// トマトを限界まで持っていないとき、トマトの壁からトマトを回収

--- a/Score.cpp
+++ b/Score.cpp
@@ -1,0 +1,15 @@
+#include "pch.h"
+#include "Score.h"
+
+Score* Score::m_score = nullptr;
+
+Score::Score()
+	: m_team1(0)
+	, m_team2(0)
+	, m_team3(0)
+{
+}
+
+Score::~Score()
+{
+}

--- a/Score.h
+++ b/Score.h
@@ -1,0 +1,67 @@
+#pragma once
+
+class Score
+{
+private:
+	static Score* m_score;
+	int m_team1;	// チーム1のスコア
+	int m_team2;	// チーム2のスコア
+	int m_team3;	// チーム3のスコア
+
+	Score();
+	~Score();
+
+public:
+	Score(const Score&) = delete;				// コピーコンストラクタをdelete指定
+	Score& operator=(const Score&) = delete;	// コピー代入演算子も　delete指定
+	Score(Score&&) = delete;					// ムーブコンストラクタを delete指定
+	Score& operator=(Score&&) = delete;			// ムーブ代入演算子も delete指定
+
+	static void GetInstance()
+	{
+		if (!m_score)
+		{
+			m_score = new Score;
+		}
+	}
+
+	static void Terminate()
+	{
+		if (m_score)
+		{
+			delete m_score;
+			m_score = nullptr;
+		}
+	}
+
+	static void AddTeam1Score()
+	{
+		m_score->m_team1 += 10;
+	}
+
+	static void AddTeam2Score()
+	{
+		m_score->m_team2 += 10;
+	}
+
+	static void AddTeam3Score()
+	{
+		m_score->m_team3 += 10;
+	}
+
+	static const int GetTeam1Score()
+	{
+		return m_score->m_team1;
+	}
+
+	static const int GetTeam2Score()
+	{
+		return m_score->m_team2;
+	}
+
+	static const int GetTeam3Score()
+	{
+		return m_score->m_team3;
+	}
+	
+};

--- a/Tomato.cpp
+++ b/Tomato.cpp
@@ -1,5 +1,8 @@
 #include "pch.h"
 #include "Tomato.h"
+#include "Object.h"
+#include "Transform.h"
+#include "Tag.h"
 
 // @detail コンストラクタ
 // @param position トマトを投げる人の位置
@@ -28,11 +31,16 @@ Tomato::~Tomato()
 	MV1DeleteModel(m_modelHandle);
 }
 
-void Tomato::Init(VECTOR& position, VECTOR& dir)
+//void Tomato::Init(VECTOR position, VECTOR dir)
+//{
+//}
+
+void Tomato::Init(VECTOR position, VECTOR dir, Tag* tag)
 {
 	m_position = position;
 	m_position = VAdd(m_position, VGet(0.0f, 15.0f, 0.0f));
 	m_dir = dir;
+	m_tag = tag;
 }
 
 // @detail 更新処理
@@ -41,6 +49,8 @@ void Tomato::Update()
 	Move();
 	m_position = VAdd(m_position, m_velocity);
 	MV1SetPosition(m_modelHandle, m_position);
+	auto pos = m_pParent->GetComponent<Transform>();
+	pos->position = m_position;
 }
 
 // @detail 描画処理

--- a/Tomato.cpp
+++ b/Tomato.cpp
@@ -4,20 +4,19 @@
 // @detail コンストラクタ
 // @param position トマトを投げる人の位置
 // @param dir 投げる人の向き
-Tomato::Tomato(VECTOR& position, VECTOR& dir)
+Tomato::Tomato()
 {
 	m_velocity = VGet(0.0f, 0.0f, 0.0f);  // 速さはまだ0
 	m_startVelocity = VGet(20.0f, 1.0f, 20.0f);
 	m_modelHandle = MV1LoadModel("data/Tomato/Tomato.mv1");
-	m_position = position;
-	m_position = VAdd(m_position, VGet(0.0f, 15.0f, 0.0f));
+	m_position = VGet(0.0f,0.0f,0.0f);
 
 	m_time = 0.0f;
 	m_gravity = 9.80665f;  // 平均重力
 	m_deg = 30.0f;
 	m_rad = m_deg * (DX_PI_F / 180.0f);
 
-	m_dir = dir;
+	m_dir = VGet(0.0f, 0.0f, 0.0f);
 
 	// サイズ調整
 	MV1SetScale(m_modelHandle, VGet(0.02f,0.02f,0.02f));
@@ -27,6 +26,13 @@ Tomato::Tomato(VECTOR& position, VECTOR& dir)
 Tomato::~Tomato()
 {
 	MV1DeleteModel(m_modelHandle);
+}
+
+void Tomato::Init(VECTOR& position, VECTOR& dir)
+{
+	m_position = position;
+	m_position = VAdd(m_position, VGet(0.0f, 15.0f, 0.0f));
+	m_dir = dir;
 }
 
 // @detail 更新処理

--- a/Tomato.h
+++ b/Tomato.h
@@ -7,12 +7,14 @@ public:
 	Tomato();   // コンストラクタ
 	~Tomato();  // デストラクタ
 
-	void Init(VECTOR& position, VECTOR& dir);  // 位置と目標方向
+	void Init(VECTOR position, VECTOR dir, class Tag* tag);  // 位置と目標方向
 	void Update();  // 更新処理
 	void Draw();  // 描画処理
 
 	float GetTime();  // トマトを投げてからの時間を返す
 	VECTOR GetPosition() { return m_position; }
+
+	class Tag* m_tag;
 private:
 	void Move();  // 投げられた後の処理
 

--- a/Tomato.h
+++ b/Tomato.h
@@ -4,9 +4,10 @@
 class Tomato : public Component
 {
 public:
-	Tomato(VECTOR& position, VECTOR& dir);   // コンストラクタ
+	Tomato();   // コンストラクタ
 	~Tomato();  // デストラクタ
 
+	void Init(VECTOR& position, VECTOR& dir);  // 位置と目標方向
 	void Update();  // 更新処理
 	void Draw();  // 描画処理
 

--- a/tomatomusou.vcxproj
+++ b/tomatomusou.vcxproj
@@ -190,6 +190,7 @@
     <ClCompile Include="Projector.cpp" />
     <ClCompile Include="RapidJson.cpp" />
     <ClCompile Include="SceneManager.cpp" />
+    <ClCompile Include="Score.cpp" />
     <ClCompile Include="TimeCount.cpp" />
     <ClCompile Include="TimeUIController.cpp" />
     <ClCompile Include="TitleScene.cpp" />
@@ -227,6 +228,7 @@
     <ClInclude Include="RapidJson.h" />
     <ClInclude Include="Scene.h" />
     <ClInclude Include="SceneManager.h" />
+    <ClInclude Include="Score.h" />
     <ClInclude Include="Tag.h" />
     <ClInclude Include="TimeCount.h" />
     <ClInclude Include="TimeUIController.h" />

--- a/tomatomusou.vcxproj
+++ b/tomatomusou.vcxproj
@@ -199,7 +199,6 @@
   <ItemGroup>
     <ClInclude Include="App.h" />
     <ClInclude Include="Camera.h" />
-    <ClInclude Include="ColliderManager.h" />
     <ClInclude Include="Collider.h" />
     <ClInclude Include="Common.h" />
     <ClInclude Include="Component.h" />

--- a/tomatomusou.vcxproj.filters
+++ b/tomatomusou.vcxproj.filters
@@ -173,9 +173,6 @@
     <ClInclude Include="Projector.h">
       <Filter>oriented</Filter>
     </ClInclude>
-    <ClInclude Include="ColliderManager.h">
-      <Filter>oriented</Filter>
-    </ClInclude>
     <ClInclude Include="TimeCount.h">
       <Filter>System</Filter>
     </ClInclude>

--- a/tomatomusou.vcxproj.filters
+++ b/tomatomusou.vcxproj.filters
@@ -79,6 +79,9 @@
     <ClCompile Include="TimeUIController.cpp">
       <Filter>GameObject</Filter>
     </ClCompile>
+    <ClCompile Include="Score.cpp">
+      <Filter>oriented</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="App.h" />
@@ -178,6 +181,9 @@
     </ClInclude>
     <ClInclude Include="TimeUIController.h">
       <Filter>GameObject</Filter>
+    </ClInclude>
+    <ClInclude Include="Score.h">
+      <Filter>oriented</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
トマトをコンポーネント化（投げて消えるRemove未処理）
エネミーとプレイヤーの中でColliderのShot関数を呼び、そこでトマトをAddComponentしObjectListsに追加して回している感じです。
何かObjectに当たりたい物にはColliderをコンポーネントする必要があります。